### PR TITLE
Fix querying existing secrets

### DIFF
--- a/pkg/controller/awssecret/awssecret_controller.go
+++ b/pkg/controller/awssecret/awssecret_controller.go
@@ -115,7 +115,7 @@ func (r *ReconcileAWSSecret) Reconcile(request reconcile.Request) (reconcile.Res
 	}
 
 	// Check if this Secret already exists
-	current := &corev1.Pod{}
+	current := &corev1.Secret{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, current)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new Secret", "Secret.Namespace", desired.Namespace, "Secret.Name", desired.Name)


### PR DESCRIPTION
Querying existing secrets does not find any results when the current is
of type Pod. This causes the updates to fail, as the controller is
trying to create a new secret instead of updating existing. Fixes #7