### PR TITLE
Cast port number as string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,8 @@ IMAGE ?= mumoshu/aws-secret-operator:canary
 
 publish:
 	operator-sdk build $(IMAGE) && docker push $(IMAGE)
+
+install-tools:
+	go get github.com/aws/aws-sdk-go/aws/session
+	go get github.com/aws/aws-sdk-go/service/secretsmanager
+	go get github.com/pkg/errors

--- a/pkg/controller/awssecret/secret.go
+++ b/pkg/controller/awssecret/secret.go
@@ -1,14 +1,14 @@
 package awssecret
 
 import (
+	"encoding/json"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"encoding/json"
 	"github.com/mumoshu/aws-secret-operator/pkg/apis/mumoshu/v1alpha1"
 )
 
 type Context struct {
-	s *session.Session
+	s  *session.Session
 	sm *secretsmanager.SecretsManager
 }
 
@@ -28,7 +28,7 @@ func (c *Context) String(secretId string, versionId string) (*string, error) {
 	}
 
 	getSecInput := &secretsmanager.GetSecretValueInput{
-		SecretId: &secretId,
+		SecretId:  &secretId,
 		VersionId: &versionId,
 	}
 
@@ -47,7 +47,14 @@ func (c *Context) SecretsManagerSecretToKubernetesStringData(ref v1alpha1.Secret
 	}
 	m := map[string]string{}
 	if err := json.Unmarshal([]byte(*sec), &m); err != nil {
-		return nil, err
+		type Port struct {
+			Number json.Number `json:"port"`
+		}
+		port := Port{}
+		if err := json.Unmarshal([]byte(*sec), &port); err != nil {
+			return nil, err
+		}
+		m["port"] = string(port.Number)
 	}
 	return m, nil
 }


### PR DESCRIPTION
Addresses #10

When using RDS secrets the port number is not a string. As a result, the
unmarshal fails. Catch this scenario and add the port as a string.

Also add a Makefile target to install required tools to build locally.