### PR TITLE
Generate new build with latest version of the AWS SDK library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-VERSION ?= 0.2.0
+VERSION ?= 0.2.1
 IMAGE ?= mumoshu/aws-secret-operator:$(VERSION)
 
 publish:
 	operator-sdk build $(IMAGE) && docker push $(IMAGE)
 
 install-tools:
+	go get github.com/aws/aws-sdk-go@v1.25.10
 	go get github.com/aws/aws-sdk-go/aws/session
 	go get github.com/aws/aws-sdk-go/service/secretsmanager
 	go get github.com/pkg/errors


### PR DESCRIPTION
The EKS team released a feature being proposed as the common solution for providing pods with IAM credentials: 
https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
This new feature requires sdk version 1.23.x, or higher.  It is also beneficial to know what version of the sdk a given build contains.  The PR proposes:
1. Updating the aws-sdk-go library to the latest.
2. Build and publish updated image.
3. Keep a known version of the aws-sdk-go library documented in the Makefile.

