### PR TITLE
Add GitHub actions CI.

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,23 @@
+name: Build
+on: [push]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.12.14
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Download Modules
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: go mod download
+      - name: Build
+        run: go build ./cmd/manager/


### PR DESCRIPTION
Add GitHub actions CI.
In current, there is no test code, but we can guarantee that the program code can be compiled.

example:

https://github.com/d-kuro/aws-secret-operator/pull/4/checks?check_run_id=376828700