### PR TITLE
Updating Dockerfile path to ./build/Dockerfile when doing make image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 
 .PHONY: image
 image:
-	DOCKERFILE_PATH=./Dockerfile IMAGE_NAME=$(IMAGE) REPO=$(REPO) hooks/build
+	DOCKERFILE_PATH=./build/Dockerfile IMAGE_NAME=$(IMAGE) REPO=$(REPO) hooks/build
 
 publish:
 	operator-sdk build $(IMAGE) && docker push $(IMAGE)


### PR DESCRIPTION
Fixes this error when running as is:
```
DOCKERFILE_PATH=./Dockerfile IMAGE_NAME=mumoshu/aws-secret-operator:0.2.4 REPO=mumoshu/aws-secret-operator hooks/build
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /Users/username/Documents/AWS/Repositories/InfraStructureScripts/aws-secret-operator/Dockerfile: no such file or directory
make: *** [image] Error 1
```