### PR TITLE
Added optional type field in spec for specifying k8s secret type

### DIFF
--- a/pkg/apis/mumoshu/v1alpha1/awssecret_types.go
+++ b/pkg/apis/mumoshu/v1alpha1/awssecret_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -12,6 +13,10 @@ type AWSSecretSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	StringDataFrom StringDataFrom `json:"stringDataFrom,omitempty"`
+
+	// Used to facilitate programmatic handling of secret data.
+	// +optional
+	Type corev1.SecretType `json:"type,omitempty"`
 }
 
 // StringDataFrom defines how the resulting Secret's `stringData` is built

--- a/pkg/controller/awssecret/awssecret_controller.go
+++ b/pkg/controller/awssecret/awssecret_controller.go
@@ -159,6 +159,7 @@ func (r *ReconcileAWSSecret) newSecretForCR(cr *mumoshuv1alpha1.AWSSecret) (*cor
 			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
+		Type:       cr.Spec.Type,
 		StringData: data,
 	}, nil
 }


### PR DESCRIPTION
Hi, I am using this operator to sync tls cert from secret manager to k8s, and want to specify the secret type (`kubernetes.io/tls`). Extended the `AWSSecret` spec to have a new field `type` which expects value in here https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go#L4793.

Example Manifest:

```
apiVersion: mumoshu.github.io/v1alpha1
kind: AWSSecret
metadata:
  name: example
spec:
  stringDataFrom:
    secretsManagerSecretRef:
      secretId: prod/mysecret
      versionId: c43e66cb-d0fe-44c5-9b7e-d450441a04be
  type: kubernetes.io/tls
```