### PR TITLE
update image tag and fix command

### DIFF
--- a/deploy/cluster_scoped/deployment.yaml
+++ b/deploy/cluster_scoped/deployment.yaml
@@ -19,12 +19,12 @@ spec:
       containers:
         - name: aws-secret-operator
           # Replace this with the built image name
-          image: mumoshu/aws-secret-operator:0.3.3
+          image: mumoshu/aws-secret-operator:0.5.0
           ports:
           - containerPort: 60000
             name: metrics
           command:
-          - aws-secret-operator
+          - /manager
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/namespaced/deployment.yaml
+++ b/deploy/namespaced/deployment.yaml
@@ -19,12 +19,12 @@ spec:
       containers:
         - name: aws-secret-operator
           # Replace this with the built image name
-          image: mumoshu/aws-secret-operator:0.3.3
+          image: mumoshu/aws-secret-operator:0.5.0
           ports:
           - containerPort: 60000
             name: metrics
           command:
-          - aws-secret-operator
+          - /manager
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
I was testing this out today (worked great) but had to fix a couple of things. I noticed the image tag was out of date as the new 0.5.0 release has been out for a couple of months. Possibly related to that update, the command also needed to be updated to be consistent with the Dockerfile (and 0.5.0 image).

I have the cluster_scoped/deployment.yaml running in a test cluster right now with these changes.