### PR TITLE
Allow "get nodes" in Kubernetes RBAC

### DIFF
--- a/deploy/cluster_scoped/rbac.yaml
+++ b/deploy/cluster_scoped/rbac.yaml
@@ -26,6 +26,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
   - mumoshu.github.io
   resources:
   - '*'

--- a/deploy/namespaced/rbac.yaml
+++ b/deploy/namespaced/rbac.yaml
@@ -43,3 +43,28 @@ roleRef:
   kind: Role
   name: aws-secret-operator
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-secret-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aws-secret-operator
+subjects:
+- kind: ServiceAccount
+  name: aws-secret-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: aws-secret-operator
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fixes https://github.com/mumoshu/aws-secret-operator/issues/58

Adds "get nodes" RBAC permission for the ClusterRole bind to aws-secret-operator service account. This privilege is needed by the leader-election functionality in [operator-lib](https://github.com/operator-framework/operator-lib/blob/main/leader/leader.go).

I created test setup for "namespaced" setup and the issue also exist in that configuration. So, I added ClusterRole and ClusterRoleBinding in namespaced RBAC.

See more detailed error description in the above-mentioned issue.

With this change, aws-secret-operator startup doesn't log errors:

```
2022-06-20T10:55:59Z    INFO    leader  Trying to become the leader.
2022-06-20T10:56:02Z    DEBUG   leader  Found podname   {"Pod.Name": "aws-secret-operator-95b776d48-txmhx"}
2022-06-20T10:56:02Z    DEBUG   leader  Found Pod       {"Pod.Namespace": "kube-system", "Pod.Name": "aws-secret-operator-95b776d48-txmhx"}
2022-06-20T10:56:02Z    INFO    leader  Found existing lock     {"LockOwner": "aws-secret-operator-95b776d48-fckjx"}
2022-06-20T10:56:02Z    INFO    leader  Not the leader. Waiting.
2022-06-20T10:56:03Z    INFO    leader  Not the leader. Waiting.
2022-06-20T10:56:05Z    INFO    leader  Not the leader. Waiting.
2022-06-20T10:56:09Z    INFO    leader  Not the leader. Waiting.
2022-06-20T10:56:19Z    INFO    leader  Became the leader.
```

In addition, I tested by scaling the aws-secret-operator deployment to multiple replicas and checked that the leader-election works as expected.