### PR TITLE
make secretId and versionId required fields

### DIFF
--- a/deploy/crds/mumoshu.github.io_awssecrets.yaml
+++ b/deploy/crds/mumoshu.github.io_awssecrets.yaml
@@ -41,6 +41,7 @@ spec:
                   encoded using base64.
                 properties:
                   secretsManagerSecretRef:
+                    required: ["secretId", "versionId"]
                     description: SecretsManagerSecretRef defines from which SecretsManager
                       Secret the Kubernetes secret is built See https://docs.aws.amazon.com/secretsmanager/latest/userguide/terms-concepts.html
                       for the concepts
@@ -71,6 +72,7 @@ spec:
                   and allows you to provide secret data as unencoded strings.
                 properties:
                   secretsManagerSecretRef:
+                    required: ["secretId", "versionId"]
                     description: SecretsManagerSecretRef defines from which SecretsManager
                       Secret the Kubernetes secret is built See https://docs.aws.amazon.com/secretsmanager/latest/userguide/terms-concepts.html
                       for the concepts


### PR DESCRIPTION
Just turning [this proposed change](https://github.com/mumoshu/aws-secret-operator/issues/45#issuecomment-1161362069) into a PR, it makes a lot of sense to have k8s validate the required fields are present upfront, making it easier for users to debug issues.

Testing on my local k8s instance with a secret missing the `versionId`:
```
kubectl apply -f /tmp/secret.yaml
error: error validating "/Users/david.lawrence/tmp/secret.yaml": error validating data: ValidationError(AWSSecret.spec.stringDataFrom.secretsManagerSecretRef): missing required field "versionId" in io.github.mumoshu.v1alpha1.AWSSecret.spec.stringDataFrom.secretsManagerSecretRef; if you choose to ignore these errors, turn validation off with --validate=false
```

Something to be aware of, though nobody should be doing this, if both `secretId` _and_ `versionId` are missing, kubernetes doesn't error, i.e. it'll accept the following file even with these updates:
```
apiVersion: mumoshu.github.io/v1alpha1
kind: AWSSecret
metadata:
  name: bad-aws-secret
  namespace: default                                                                                                                                                                                                                    
spec:
  stringDataFrom:
    secretsManagerSecretRef:
```